### PR TITLE
Retention Analysis

### DIFF
--- a/app/assets/javascripts/application.js.coffee
+++ b/app/assets/javascripts/application.js.coffee
@@ -9,6 +9,7 @@
 #= require daterangepicker/daterangepicker
 #= require jquery-timepicker-1.11.1/jquery.timepicker
 #= require chart.js-2.0.0-beta2/Chart
+#= require cornelius-24d9358/cornelius
 #= require chartkick
 #= require jsUri/Uri
 #= require cocoon
@@ -26,3 +27,4 @@
 #= require pages/notifications/notification_sending_progress
 #= require pages/bots/verifying_webhook
 #= require pages/insights/filter
+#= require pages/retention/index

--- a/app/assets/javascripts/pages/retention/index.js.coffee
+++ b/app/assets/javascripts/pages/retention/index.js.coffee
@@ -1,0 +1,21 @@
+#= require pages/app/base
+
+window.App ||= {}
+
+class App.RetentionIndex extends App.AppBase
+  constructor: (@retentionNumbers, @startDate) ->
+    super()
+    @startDate = new Date(@startDate)
+
+  run: ->
+    self = @
+    $(document).ready ->
+      container = document.getElementById('retention')
+
+      Cornelius.draw
+        initialDate: self.startDate
+        container: container
+        cohort: self.retentionNumbers
+        title: 'Weekly Retention (Last 8 Weeks)'
+        timeInterval: 'weekly'
+

--- a/app/assets/javascripts/pages/retention/index.js.coffee
+++ b/app/assets/javascripts/pages/retention/index.js.coffee
@@ -3,19 +3,58 @@
 window.App ||= {}
 
 class App.RetentionIndex extends App.AppBase
-  constructor: (@retentionNumbers, @startDate) ->
+  constructor: (@retentionNumbers, @start, @end, @groupBy) ->
+    @startDate = new Date(@start)
+    @endDate = new Date(@end)
+    @start = moment(@start)
+    @end = moment(@end)
     super()
-    @startDate = new Date(@startDate)
 
   run: ->
     self = @
     $(document).ready ->
       container = document.getElementById('retention')
 
+      timeInterval = switch self.groupBy
+        when 'week'   then 'weekly'
+        when 'day'    then 'daily'
+        when 'month'  then 'monthly'
+        else 'weekly'
+
+      intervalString = "(#{self.startDate.toLocaleDateString()} - #{self.endDate.toLocaleDateString()})"
+      title = switch self.groupBy
+        when 'week'   then "Weekly Retention #{intervalString}"
+        when 'day'    then "Daily Retention #{intervalString}"
+        when 'month'  then "Monthly Retention #{intervalString}"
+
       Cornelius.draw
         initialDate: self.startDate
         container: container
         cohort: self.retentionNumbers
-        title: 'Weekly Retention (Last 8 Weeks)'
-        timeInterval: 'weekly'
+        title: title
+        timeInterval: timeInterval
+
+      cb = (start, end) ->
+        $('#report-range span').html(start.format('MMM D, YYYY') + ' - ' + end.format('MMM D, YYYY'))
+      cb(self.start, self.end)
+
+      $('#report-range').daterangepicker
+        ranges:
+          'Last 4 weeks': [moment().subtract(4, 'weeks'), moment()]
+          'Last 8 weeks': [moment().subtract(2, 'months'), moment()]
+          'Last 16 weeks': [moment().subtract(4, 'months'), moment()]
+          'Last 24 weeks': [moment().subtract(6, 'months'), moment()]
+        , cb
+      $('#report-range').on 'apply.daterangepicker', (ev, picker) ->
+        start = picker.startDate.format('MMM DD, YYYY')
+        end = picker.endDate.format('MMM DD, YYYY')
+        uri = new Uri(window.location.href).
+                replaceQueryParam('start', start).
+                replaceQueryParam('end', end).toString()
+        Turbolinks.visit(uri)
+      $('.time-segmented-controls a').click (e) ->
+        uri = new Uri(window.location.href).
+                replaceQueryParam('group_by', $(this).attr('data-group')).toString()
+        Turbolinks.visit(uri)
+        e.preventDefault()
 

--- a/app/assets/stylesheets/app.sass
+++ b/app/assets/stylesheets/app.sass
@@ -169,7 +169,8 @@ body.dashboards.disabled_bots,
 body.dashboards.users,
 body.dashboards.all_messages,
 body.dashboards.messages_to_bot,
-body.dashboards.messages_from_bot
+body.dashboards.messages_from_bot,
+body.retention.index
   .time-segmented-controls
     margin-right: 15px
   .tableized

--- a/app/assets/stylesheets/app.sass
+++ b/app/assets/stylesheets/app.sass
@@ -6,7 +6,8 @@ body.dashboards,
 body.notifications,
 body.new_notification,
 body.edit_notification,
-body.insights
+body.insights,
+body.retention.index
   .update-instance
     display: none
   .integrate-cta
@@ -99,7 +100,8 @@ body.notifications,
 body.new_notification,
 body.edit_notification,
 body.users,
-body.insights
+body.insights,
+body.retention.index
   &.edit
     h2.api
       padding-top: 10px
@@ -208,7 +210,8 @@ body.new_notification,
 body.edit_notification,
 body.users,
 body.bot_instances,
-body.insights
+body.insights,
+body.retention.index
   background-color: rgba(227,231,242, 0.1)
   .secondary-menu
     background-color: #fff
@@ -390,3 +393,9 @@ body.bot_instances.new
     padding-top: 20px
   .onboarding-tips
     padding-top: 20px
+
+body.retention.index
+  #retention
+    min-height: 550px
+  .retention-details
+    font-size: 20px

--- a/app/assets/stylesheets/app.sass
+++ b/app/assets/stylesheets/app.sass
@@ -400,3 +400,6 @@ body.retention.index
     min-height: 550px
   .retention-details
     font-size: 20px
+  .cornelius-table
+    td, th
+      font-family: Lucida Grande

--- a/app/assets/stylesheets/application.sass
+++ b/app/assets/stylesheets/application.sass
@@ -22,3 +22,5 @@
 @import "daterangepicker/daterangepicker"
 @import "jquery-timepicker-1.11.1/jquery.timepicker"
 @import "highlight.js-9.5.0/solarized-dark"
+@import "cornelius-24d9358/cornelius"
+

--- a/app/controllers/retention_controller.rb
+++ b/app/controllers/retention_controller.rb
@@ -5,15 +5,36 @@ class RetentionController < ApplicationController
   layout 'app'
 
   def index
-    @retention = [
-      BotUser.by_cohort(@bot, start_time: 8.weeks.ago),
-      BotUser.by_cohort(@bot, start_time: 7.weeks.ago),
-      BotUser.by_cohort(@bot, start_time: 6.weeks.ago),
-      BotUser.by_cohort(@bot, start_time: 5.weeks.ago),
-      BotUser.by_cohort(@bot, start_time: 4.weeks.ago),
-      BotUser.by_cohort(@bot, start_time: 3.weeks.ago),
-      BotUser.by_cohort(@bot, start_time: 2.weeks.ago),
-      BotUser.by_cohort(@bot, start_time: 1.week.ago)
-    ]
+    @group_by = params[:group_by].presence || 'week'
+    @start = params[:start].to_s.in_time_zone(current_user.timezone) || 4.weeks.ago
+    @end = params[:end].to_s.in_time_zone(current_user.timezone) || Time.current
+
+    @retention = retention_metrics
+  end
+
+  private
+  def retention_metrics
+    periods = 0
+    retention = []
+
+    case @group_by
+    when 'day'
+      periods = ((@end.to_i - @start.to_i).to_f / (24 * 60 * 60)).ceil
+      (0...periods).each do |period|
+        retention << BotUser.by_cohort(@bot, start_time: @start + period.days, end_time: @end, group_by: @group_by)
+      end
+    when 'week'
+      periods = ((@end.to_i - @start.to_i).to_f / (24 * 60 * 60 * 7)).ceil
+      (0...periods).each do |period|
+        retention << BotUser.by_cohort(@bot, start_time: @start + period.weeks, end_time: @end, group_by: @group_by)
+      end
+    when 'month'
+      periods = ((@end.to_i - @start.to_i).to_f / (24 * 60 * 60 * 30)).ceil
+      (0...periods).each do |period|
+        retention << BotUser.by_cohort(@bot, start_time: @start + period.months, end_time: @end, group_by: @group_by)
+      end
+    end
+
+    retention
   end
 end

--- a/app/controllers/retention_controller.rb
+++ b/app/controllers/retention_controller.rb
@@ -1,0 +1,19 @@
+class RetentionController < ApplicationController
+  before_action :authenticate_user!
+  before_action :find_bot
+
+  layout 'app'
+
+  def index
+    @retention = [
+      BotUser.by_cohort(@bot, start_time: 8.weeks.ago),
+      BotUser.by_cohort(@bot, start_time: 7.weeks.ago),
+      BotUser.by_cohort(@bot, start_time: 6.weeks.ago),
+      BotUser.by_cohort(@bot, start_time: 5.weeks.ago),
+      BotUser.by_cohort(@bot, start_time: 4.weeks.ago),
+      BotUser.by_cohort(@bot, start_time: 3.weeks.ago),
+      BotUser.by_cohort(@bot, start_time: 2.weeks.ago),
+      BotUser.by_cohort(@bot, start_time: 1.week.ago)
+    ]
+  end
+end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -12,6 +12,8 @@ module ApplicationHelper
       'active'
     elsif controller.controller_name == 'insights' && link == 'analyze'
       'active'
+    elsif controller.controller_name == 'retention' && link == 'retention'
+      'active'
     end
   end
 

--- a/app/models/bot_user.rb
+++ b/app/models/bot_user.rb
@@ -135,16 +135,42 @@ class BotUser < ActiveRecord::Base
     order("last_event_at DESC NULLS LAST")
   end
 
-  def self.by_cohort(bot, start_time: 8.weeks.ago, group_by: 'week')
-    start_time = start_time.beginning_of_week
-    end_time = Time.current.end_of_week
-    # number of weeks
-    periods = ((end_time.to_i - start_time.to_i).to_f / (24 * 60 * 60 * 7)).ceil
+  def self.by_cohort(bot, start_time: 8.weeks.ago, end_time: Time.current, group_by: 'week')
+    start_time = case group_by
+                 when 'day' then start_time.beginning_of_day
+                 when 'week' then start_time.beginning_of_week
+                 when 'month' then start_time.beginning_of_month
+                 end
+
+    first_cohort_end = case group_by
+    when 'day'
+      start_time.end_of_day
+    when 'week'
+      start_time.end_of_week
+    when 'month'
+      start_time.end_of_month
+    end
+
+    end_time = case group_by
+                 when 'day' then end_time.end_of_day
+                 when 'week' then end_time.end_of_week
+                 when 'month' then end_time.end_of_month
+                 end
+    # number of periods
+    multiplier = case group_by
+                 when 'day' then 1
+                 when 'week' then 7
+                 when 'month' then 30
+                 end
+
+    periods = ((end_time.to_i - start_time.to_i).to_f / (24 * 60 * 60 * multiplier)).ceil
+    start_time_string = start_time.strftime('%Y-%m-%d %H:%M:%S.%N')
+    first_cohort_end_string = first_cohort_end.strftime('%Y-%m-%d %H:%M:%S.%N')
 
     bot_instance_ids = bot.instances.pluck("bot_instances.id")
-    first_cohort = sanitize_sql_hash_for_conditions("esub.created_at" => start_time..start_time.end_of_week)
-    users_condition = sanitize_sql_hash_for_conditions("bot_users.created_at" => start_time..start_time.end_of_week)
-    bot_condition = sanitize_sql_hash_for_conditions("esub.bot_instance_id" => bot_instance_ids)
+    first_cohort = sanitize_sql_for_conditions(["esub.created_at BETWEEN :start_time AND :end_time", start_time: start_time_string, end_time: first_cohort_end_string])
+    users_condition = sanitize_sql_for_conditions(["bot_users.created_at BETWEEN :start_time AND :end_time AND bot_users.bot_instance_id IN (:bot_instances)", start_time: start_time_string, end_time: first_cohort_end_string, bot_instances: bot_instance_ids])
+    bot_condition = sanitize_sql_for_conditions(["esub.bot_instance_id IN (?)", bot_instance_ids])
 
     counts = []
     periods.times { |i| counts << "COUNT(DISTINCT e#{i+1}.bot_user_id)" }
@@ -164,7 +190,19 @@ class BotUser < ActiveRecord::Base
     """
 
     (2..periods).each do |i|
-      next_cohort = sanitize_sql_hash_for_conditions("esub.created_at" => (start_time + (i-1).week)..(start_time + (i-1).week).end_of_week)
+      next_start, next_end = case group_by
+      when 'day'
+        [(start_time + (i-1).send(group_by)), (start_time + (i-1).send(group_by)).end_of_day]
+      when 'week'
+        [(start_time + (i-1).send(group_by)), (start_time + (i-1).send(group_by)).end_of_week]
+      when 'month'
+        [(start_time + (i-1).send(group_by)), (start_time + (i-1).send(group_by)).end_of_month]
+      end
+
+      next_start = next_start.strftime('%Y-%m-%d %H:%M:%S.%N')
+      next_end = next_end.strftime('%Y-%m-%d %H:%M:%S.%N')
+
+      next_cohort = sanitize_sql_for_conditions(["esub.created_at BETWEEN :start_time AND :end_time", start_time: next_start, end_time: next_end])
       sql << """
         LEFT OUTER JOIN LATERAL (
          SELECT * FROM events esub

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -55,4 +55,8 @@ class Event < ActiveRecord::Base
       relation.where("(event_attributes->>'sub_type')::text IS NOT NULL AND (event_attributes->>'sub_type')::text = ?", type)
     end
   end
+
+  def created_at_string
+    self.created_at.to_s('%Y-%m-%d %H:%M:%S.%N')
+  end
 end

--- a/app/views/dashboards/show.html.haml
+++ b/app/views/dashboards/show.html.haml
@@ -23,7 +23,7 @@
         %h3
           Messages Matching:
           %pre= "\"#{@dashboard.regex}\""
-    .col-md-123.col-sm-12.col-xs-12.graph-container
+    .col-md-12.col-sm-12.col-xs-12.graph-container
       = line_chart @dashboard.data, solo_chartjs_opts(@group_by)
       = render 'table', dashboard: @dashboard
       = will_paginate @dashboard.tableized, renderer: BootstrapPagination::Rails

--- a/app/views/layouts/app.html.haml
+++ b/app/views/layouts/app.html.haml
@@ -43,6 +43,10 @@
                 = icon('pie-chart')
                 Insights
             %li
+              = link_to bot_retention_index_path(@bot), class: menu_class('retention') do
+                = icon('refresh')
+                Retention
+            %li
               = link_to bot_notifications_path(@bot), class: menu_class('notifications') do
                 = icon('comment')
                 Notifications

--- a/app/views/retention/index.html.haml
+++ b/app/views/retention/index.html.haml
@@ -1,0 +1,20 @@
+.secondary-menu.row
+  .col-md-5.col-sm-3.col-xs-6
+    = link_to bot_dashboards_path(@bot), class: 'breadcrumb' do
+      %h2 All Metrics
+    %span.breadcrumb-separator
+      \/
+    %h2
+      Retention
+
+.container-fluid.retention-container
+  .graph.row
+    .col-md-12.col-sm-12.col-xs-12#retention
+    .retention-details.text-center
+      %p.retention-details
+        Each cohort represents users that signed up in that week and interacted with your bot at least once.
+
+- content_for :page_scripts do
+  :javascript
+    App.page = new App.RetentionIndex(#{@retention.to_json}, #{8.weeks.ago.beginning_of_week.to_json});
+    App.page.run();

--- a/app/views/retention/index.html.haml
+++ b/app/views/retention/index.html.haml
@@ -6,15 +6,21 @@
       \/
     %h2
       Retention
+  .col-md-7.col-sm-9.col-xs-6.text-right
+    #report-range.pull-right
+      = icon('calendar')
+      %span
+      %b.caret
+    .btn-group.time-segmented-controls.pull-right
+      = link_to 'Daily', bot_retention_index_path(@bot), class: (@group_by == 'day' ? 'btn active' : 'btn'), data: { group: 'day' }
+      = link_to 'Weekly', bot_retention_index_path(@bot, group_by: 'week'), class: (@group_by == 'week' ? 'btn active' : 'btn'), data: { group: 'week' }
+      = link_to 'Monthly', bot_retention_index_path(@bot, group_by: 'month'), class: (@group_by == 'month' ? 'btn active' : 'btn'), data: { group: 'month' }
 
 .container-fluid.retention-container
   .graph.row
     .col-md-12.col-sm-12.col-xs-12#retention
-    .retention-details.text-center
-      %p.retention-details
-        Each cohort represents users that signed up in that week and interacted with your bot at least once.
 
 - content_for :page_scripts do
   :javascript
-    App.page = new App.RetentionIndex(#{@retention.to_json}, #{8.weeks.ago.beginning_of_week.to_json});
+    App.page = new App.RetentionIndex(#{@retention.to_json}, #{@start.to_json}, #{@end.to_json}, #{@group_by.to_json});
     App.page.run();

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,6 +18,8 @@ Rails.application.routes.draw do
       end
     end
 
+    resources :retention, only: [:index]
+
     resources :notifications, except: [:new, :create, :edit, :update]
     resources :new_notification, only: [:create] do
       collection do

--- a/db/migrate/20161031165417_add_index_on_events_created_at_when_is_for_bot_is_true.rb
+++ b/db/migrate/20161031165417_add_index_on_events_created_at_when_is_for_bot_is_true.rb
@@ -1,0 +1,5 @@
+class AddIndexOnEventsCreatedAtWhenIsForBotIsTrue < ActiveRecord::Migration
+  def change
+    add_index :events, :created_at, where: "is_for_bot = 't'"
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -960,6 +960,13 @@ CREATE INDEX index_events_on_bot_user_id ON events USING btree (bot_user_id);
 
 
 --
+-- Name: index_events_on_created_at; Type: INDEX; Schema: public; Owner: -; Tablespace:
+--
+
+CREATE INDEX index_events_on_created_at ON events USING btree (created_at) WHERE (is_for_bot = true);
+
+
+--
 -- Name: index_events_on_event_type; Type: INDEX; Schema: public; Owner: -; Tablespace:
 --
 
@@ -1362,4 +1369,6 @@ INSERT INTO schema_migrations (version) VALUES ('20160919065157');
 INSERT INTO schema_migrations (version) VALUES ('20161004235348');
 
 INSERT INTO schema_migrations (version) VALUES ('20161012225313');
+
+INSERT INTO schema_migrations (version) VALUES ('20161031165417');
 

--- a/spec/controllers/retention_controller_spec.rb
+++ b/spec/controllers/retention_controller_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe RetentionController, type: :controller do
+
+end

--- a/spec/models/bot_user_spec.rb
+++ b/spec/models/bot_user_spec.rb
@@ -269,48 +269,142 @@ RSpec.describe BotUser do
     let!(:bi1) { create :bot_instance, bot: bot }
     let!(:bi2) { create :bot_instance, bot: bot }
 
-    before do
-      travel_to Time.current
-      @start_time = 8.weeks.ago.beginning_of_week
+    context 'weekly retention' do
+      before do
+        travel_to Time.current
+        @start_time = 8.weeks.ago.beginning_of_week
 
-      @users = []
+        @users = []
 
-      # Create users for 8 weeks, each week starts with 10 users
-      count = 1
-
-      9.times do |i|
-        sub_users = []
-        (10*count).times do
-          sub_users << create(:bot_user, bot_instance: bi1, created_at: @start_time + i.weeks + 1.hour)
-        end
-        @users << sub_users
-        count += 1
-      end
-
-      @users.each_with_index do |sub_users, index|
-        # Every user is active in the first week
-        sub_users.each do |user|
-          create(:event, bot_instance: bi1, is_for_bot: true, user: user, created_at: @start_time + index.weeks + 1.hour)
-          create(:event, bot_instance: bi1, is_for_bot: false, user: user, created_at: @start_time + index.weeks + 1.hour)
-        end
+        # Create users for 8 weeks, each week starts with 10 users
         count = 1
-        (index+1...9).each do |j|
-          (0...sub_users.length-count).each do |idx|
-            user = sub_users[idx]
-            create(:event, bot_instance: bi1, is_for_bot: true, user: user, created_at: @start_time + j.weeks + 1.hour)
-            create(:event, bot_instance: bi1, is_for_bot: false, user: user, created_at: @start_time + j.weeks + 1.hour)
+
+        9.times do |i|
+          sub_users = []
+          (10*count).times do
+            sub_users << create(:bot_user, bot_instance: bi1, created_at: @start_time + i.weeks + 1.hour)
           end
+          @users << sub_users
           count += 1
         end
+
+        @users.each_with_index do |sub_users, index|
+          # Every user is active in the first week
+          sub_users.each do |user|
+            create(:event, bot_instance: bi1, is_for_bot: true, user: user, created_at: @start_time + index.weeks + 1.hour)
+            create(:event, bot_instance: bi1, is_for_bot: false, user: user, created_at: @start_time + index.weeks + 1.hour)
+          end
+          count = 1
+          (index+1...9).each do |j|
+            (0...sub_users.length-count).each do |idx|
+              user = sub_users[idx]
+              create(:event, bot_instance: bi1, is_for_bot: true, user: user, created_at: @start_time + j.weeks + 1.hour)
+              create(:event, bot_instance: bi1, is_for_bot: false, user: user, created_at: @start_time + j.weeks + 1.hour)
+            end
+            count += 1
+          end
+        end
+      end
+
+      after { travel_back }
+
+      it 'should return the number of users per cohort' do
+        expect(BotUser.by_cohort(bot, start_time: 8.weeks.ago)).to eql [10, 9, 8, 7, 6, 5, 4, 3, 2]
+        expect(BotUser.by_cohort(bot, start_time: 7.weeks.ago)).to eql [20, 19, 18, 17, 16, 15, 14, 13]
+        expect(BotUser.by_cohort(bot, start_time: 6.weeks.ago)).to eql [30, 29, 28, 27, 26, 25, 24]
       end
     end
 
-    after { travel_back }
+    context 'daily retention' do
+      before do
+        travel_to Time.current
+        @start_time = 8.days.ago.beginning_of_day
 
-    it 'should return the number of users per cohort' do
-      expect(BotUser.by_cohort(bot, start_time: 8.weeks.ago)).to eql [10, 9, 8, 7, 6, 5, 4, 3, 2]
-      expect(BotUser.by_cohort(bot, start_time: 7.weeks.ago)).to eql [20, 19, 18, 17, 16, 15, 14, 13]
-      expect(BotUser.by_cohort(bot, start_time: 6.weeks.ago)).to eql [30, 29, 28, 27, 26, 25, 24]
+        @users = []
+
+        # Create users for 8 weeks, each week starts with 10 users
+        count = 1
+
+        9.times do |i|
+          sub_users = []
+          (10*count).times do
+            sub_users << create(:bot_user, bot_instance: bi1, created_at: @start_time + i.days + 1.hour)
+          end
+          @users << sub_users
+          count += 1
+        end
+
+        @users.each_with_index do |sub_users, index|
+          # Every user is active in the first week
+          sub_users.each do |user|
+            create(:event, bot_instance: bi1, is_for_bot: true, user: user, created_at: @start_time + index.days + 1.hour)
+            create(:event, bot_instance: bi1, is_for_bot: false, user: user, created_at: @start_time + index.days + 1.hour)
+          end
+          count = 1
+          (index+1...9).each do |j|
+            (0...sub_users.length-count).each do |idx|
+              user = sub_users[idx]
+              create(:event, bot_instance: bi1, is_for_bot: true, user: user, created_at: @start_time + j.days + 1.hour)
+              create(:event, bot_instance: bi1, is_for_bot: false, user: user, created_at: @start_time + j.days + 1.hour)
+            end
+            count += 1
+          end
+        end
+      end
+
+      after { travel_back }
+
+      it 'should return the number of users per cohort' do
+        expect(BotUser.by_cohort(bot, start_time: 8.days.ago, group_by: 'day')).to eql [10, 9, 8, 7, 6, 5, 4, 3, 2]
+        expect(BotUser.by_cohort(bot, start_time: 7.days.ago, group_by: 'day')).to eql [20, 19, 18, 17, 16, 15, 14, 13]
+        expect(BotUser.by_cohort(bot, start_time: 6.days.ago, group_by: 'day')).to eql [30, 29, 28, 27, 26, 25, 24]
+      end
+    end
+
+    context 'monthly retention' do
+      before do
+        travel_to Time.current
+        @start_time = 8.months.ago.beginning_of_month
+
+        @users = []
+
+        # Create users for 8 weeks, each week starts with 10 users
+        count = 1
+
+        9.times do |i|
+          sub_users = []
+          (10*count).times do
+            sub_users << create(:bot_user, bot_instance: bi1, created_at: @start_time + i.months + 1.hour)
+          end
+          @users << sub_users
+          count += 1
+        end
+
+        @users.each_with_index do |sub_users, index|
+          # Every user is active in the first week
+          sub_users.each do |user|
+            create(:event, bot_instance: bi1, is_for_bot: true, user: user, created_at: @start_time + index.months + 1.hour)
+            create(:event, bot_instance: bi1, is_for_bot: false, user: user, created_at: @start_time + index.months + 1.hour)
+          end
+          count = 1
+          (index+1...9).each do |j|
+            (0...sub_users.length-count).each do |idx|
+              user = sub_users[idx]
+              create(:event, bot_instance: bi1, is_for_bot: true, user: user, created_at: @start_time + j.months + 1.hour)
+              create(:event, bot_instance: bi1, is_for_bot: false, user: user, created_at: @start_time + j.months + 1.hour)
+            end
+            count += 1
+          end
+        end
+      end
+
+      after { travel_back }
+
+      it 'should return the number of users per cohort' do
+        expect(BotUser.by_cohort(bot, start_time: 8.months.ago, group_by: 'month')).to eql [10, 9, 8, 7, 6, 5, 4, 3, 2, 0]
+        expect(BotUser.by_cohort(bot, start_time: 7.months.ago, group_by: 'month')).to eql [20, 19, 18, 17, 16, 15, 14, 13, 0]
+        expect(BotUser.by_cohort(bot, start_time: 6.months.ago, group_by: 'month')).to eql [30, 29, 28, 27, 26, 25, 24, 0]
+      end
     end
   end
 end

--- a/vendor/assets/javascripts/cornelius-24d9358/cornelius.js
+++ b/vendor/assets/javascripts/cornelius-24d9358/cornelius.js
@@ -1,0 +1,302 @@
+/*!
+ * Cornelius library v0.1
+ * http://restorando.github.io/cornelius
+ *
+ * Copyright (c) 2013 Restorando
+ * Released under the MIT license
+ *
+ * Date: 2013-06-04
+ */
+
+;(function(globals) {
+    var corneliusDefaults = {
+        monthNames: ['January', 'February', 'March', 'April', 'May', 'June', 'July',
+                     'August', 'September', 'October', 'November', 'December'],
+
+        shortMonthNames: ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul',
+                          'Aug', 'Sep', 'Oct', 'Nov', 'Dec'],
+
+        repeatLevels: {
+            'low': [0, 10],
+            'medium-low': [10, 20],
+            'medium': [20, 30],
+            'medium-high': [30, 40],
+            'high': [40, 60],
+            'hot': [60, 70],
+            'extra-hot': [70, 100]
+        },
+
+        labels: {
+            time: 'Time',
+            people: 'People',
+            weekOf: 'Week of'
+        },
+
+        timeInterval: 'monthly',
+
+        drawEmptyCells: true,
+
+        rawNumberOnHover: true,
+
+        displayAbsoluteValues: false,
+
+        initialIntervalNumber: 1,
+
+        classPrefix: 'cornelius-',
+
+        formatHeaderLabel: function(i) {
+            return (this.initialIntervalNumber - 1 + i).toString();
+        },
+
+        formatDailyLabel: function(date, i) {
+            date.setDate(date.getDate() + i);
+            return this.monthNames[date.getMonth()] + ' ' + date.getDate() + ', ' + getYear(date);
+        },
+
+        formatWeeklyLabel: function(date, i) {
+            date.setDate(date.getDate() + i * 7);
+            return this.labels.weekOf + ' ' + this.shortMonthNames[date.getMonth()] + ' ' +
+                    date.getDate() + ', ' + getYear(date);
+        },
+
+        formatMonthlyLabel: function(date, i) {
+            date.setMonth(date.getMonth() + i);
+            return this.monthNames[date.getMonth()] + ' ' + getYear(date);
+        },
+
+        formatYearlyLabel: function(date, i) {
+            return date.getYear() + 1900 + i;
+        }
+    },
+
+    defaults = corneliusDefaults;
+
+    function extend() {
+        var target = arguments[0];
+
+        if (arguments.length === 1) return target;
+
+        for (var i = 1; i < arguments.length; i++) {
+            var source = arguments[i];
+            for (var prop in source) target[prop] = source[prop];
+        }
+
+        return target;
+    }
+
+    function isNumber(val) {
+        return Object.prototype.toString.call(val) === '[object Number]';
+    }
+
+    function isEmpty(val) {
+        return val === null || val === undefined || val === "";
+    }
+
+    function getYear(date) {
+        return date.getFullYear ? date.getFullYear() : date.getYear() + 1900;
+    }
+
+    var draw = function(cornelius, cohort, container) {
+        if (!cohort)    throw new Error ("Please provide the cohort data");
+        if (!container) throw new Error ("Please provide the cohort container");
+
+        var config = cornelius.config,
+            initialDate = cornelius.initialDate;
+
+        function create(el, options) {
+            options = options || {};
+
+            el = document.createElement(el);
+
+            if ((className = options.className)) {
+                delete options.className;
+                el.className = prefixClass(className);
+            }
+            if (!isEmpty(options.text)) {
+                var text = options.text.toString();
+
+                if (document.all) {
+                    el.innerText = text;
+                } else {
+                    el.textContent = text;
+                }
+                delete options.text;
+            }
+
+            for (var option in options) {
+                if ((opt = options[option])) el[option] = opt;
+            }
+
+            return el;
+        }
+
+
+        // prefix any css class we use in order to avoid any possible clashes
+
+        function prefixClass(className) {
+            var prefixedClass = [],
+                classes = className.split(/\s+/);
+
+            for (var i in classes) {
+                prefixedClass.push(config.classPrefix + classes[i]);
+            }
+            return prefixedClass.join(" ");
+        }
+
+        function drawHeader(data) {
+            var th = create('tr'),
+                monthLength = data[0].length;
+
+            th.appendChild(create('th', { text: config.labels.time, className: 'time' }));
+
+            for (var i = 0; i < monthLength; i++) {
+                if (i > config.maxColumns) break;
+                var text = i === 0 ? config.labels.people : config.formatHeaderLabel(i);
+                th.appendChild(create('th', { text: text, className: 'people' }));
+            }
+            return th;
+        }
+
+        function formatTimeLabel(initial, timeInterval, i) {
+            var date = new Date(initial.getTime()),
+                formatFn = null;
+
+            if (timeInterval === 'daily') {
+                formatFn = 'formatDailyLabel';
+            } else if (timeInterval === 'weekly') {
+                formatFn = 'formatWeeklyLabel';
+            } else if (timeInterval === 'monthly') {
+                formatFn = 'formatMonthlyLabel';
+            } else if (timeInterval === 'yearly') {
+                formatFn = 'formatYearlyLabel';
+            } else {
+                throw new Error("Interval not supported");
+            }
+
+            return config[formatFn].call(config, date, i);
+        }
+
+        function drawCells(data) {
+            var fragment = document.createDocumentFragment(),
+
+                startMonth = config.maxRows ? data.length - config.maxRows : 0,
+
+                formatPercentage = function(value, base) {
+                    if (isNumber(value) && base > 0) {
+                        return (value / base * 100).toFixed(2);
+                    } else if (isNumber(value)) {
+                        return "0.00";
+                    }
+                },
+
+                classNameFor = function(value) {
+                    var levels = config.repeatLevels,
+                        floatValue = value && parseFloat(value),
+                        highestLevel = null;
+
+                    var classNames = [config.displayAbsoluteValues ? 'absolute' : 'percentage'];
+
+                    for (var level in levels) {
+                        if (floatValue >= levels[level][0] && floatValue < levels[level][1]) {
+                            classNames.push(level);
+                            return classNames.join(" ");
+                        }
+                        highestLevel = level;
+                    }
+
+                    // handle 100% case
+                    classNames.push(highestLevel);
+                    return classNames.join(" ");
+
+                };
+
+            for (var i = startMonth; i < data.length; i++) {
+                var tr = create('tr'),
+                    row = data[i],
+                    baseValue = row[0];
+
+                tr.appendChild(create('td', {
+                    className: 'label',
+                    text: formatTimeLabel(initialDate, config.timeInterval, i)
+                }));
+
+                for (var j = 0; j < data[0].length; j++) {
+                    if (j > config.maxColumns) break;
+
+                    var value = row[j],
+                        formattedPercentage = formatPercentage(value, baseValue),
+                        cellValue = j === 0 || config.displayAbsoluteValues ? value : formattedPercentage,
+                        opts = {};
+
+                        if (!isEmpty(cellValue)) {
+                            opts = {
+                                text: cellValue,
+                                title: j > 0 && config.rawNumberOnHover ? value : null,
+                                className: j === 0 ? 'people' : classNameFor(formattedPercentage)
+                            };
+                        } else if (config.drawEmptyCells) {
+                            opts = { text: '-', className: 'empty' };
+                        }
+
+                    tr.appendChild(create('td', opts));
+                }
+                fragment.appendChild(tr);
+            }
+            return fragment;
+        }
+
+        var mainContainer = create('div', { className: 'container' }),
+            table = create('table', { className: 'table' });
+
+        table.appendChild(drawHeader(cohort));
+        table.appendChild(drawCells(cohort));
+
+        if ((title = config.title)) {
+            mainContainer.appendChild(create('div', { text: title, className: 'title' }));
+        }
+        mainContainer.appendChild(table);
+
+        container.innerHTML = "";
+        container.appendChild(mainContainer);
+    };
+
+    var Cornelius = function(opts) {
+        if (!(initialDate = opts.initialDate)) throw new Error('The initialDate is a required argument');
+        delete opts.initialDate;
+
+        this.initialDate = initialDate;
+        this.config = extend({}, Cornelius.getDefaults(), opts || {});
+    };
+
+    extend(Cornelius, {
+        getDefaults: function() {
+            return defaults;
+        },
+
+        setDefaults: function(def) {
+            defaults = extend({}, corneliusDefaults, def);
+        },
+
+        resetDefaults: function() {
+            defaults = corneliusDefaults;
+        },
+        draw: function(options) {
+            var cornelius = new Cornelius(options);
+            draw(cornelius, options.cohort, options.container);
+            return options.container;
+        }
+    });
+
+    if (typeof globals.jQuery !== "undefined" && globals.jQuery !== null) {
+        globals.jQuery.fn.cornelius = function(options) {
+            return this.each(function() {
+                options.container = this;
+                return Cornelius.draw(options);
+            });
+        };
+    }
+
+    // show it to the world!!
+    globals.Cornelius = Cornelius;
+
+})(window);

--- a/vendor/assets/stylesheets/cornelius-24d9358/cornelius.css
+++ b/vendor/assets/stylesheets/cornelius-24d9358/cornelius.css
@@ -1,0 +1,116 @@
+.cornelius-container {
+  font-family: Helvetica;
+  padding: 20px 0;
+}
+
+.cornelius-title {
+  text-align: center;
+  padding-bottom: 20px;
+  font-weight: bold;
+  font-size: 14pt;
+  color: #3A3838;
+}
+
+.cornelius-table {
+  font-size: 9pt;
+  margin: auto;
+  border-spacing: 0;
+  border-collapse: collapse;
+  -webkit-box-shadow: rgba(0,0,0,0.18) 0 0 10px;
+  -moz-box-shadow: rgba(0,0,0,0.18) 0 0 10px;
+  box-shadow: rgba(0,0,0,0.18) 0 0 10px;
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  border-radius: 10px;
+  background-color: #F5F3F3;
+}
+
+/* fix for last cell rounded corner bug */
+.cornelius-table tr:last-child td:last-child {
+  -webkit-border-bottom-right-radius: 10px;
+  -moz-border-bottom-right-radius: 10px;
+  border-bottom-right-radius: 10px;
+}
+
+.cornelius-table tr:first-child th:last-child {
+  border-right: none;
+}
+
+.cornelius-table td, .cornelius-table th{
+  width: 42px;
+  text-align: center;
+  padding: 10px;
+}
+
+.cornelius-table th {
+  border-bottom: 1px solid #E4E4E4;
+  border-right: 1px solid #E4E4E4;
+  color: #3A3838;
+  font-weight: bold;
+}
+
+.cornelius-percentage {
+  border: none;
+  color: #000;
+}
+
+.cornelius-percentage:after {
+  content: "%";
+  margin-left: 2px;
+}
+
+td.cornelius-label {
+  text-align: left;
+  width: 135px;
+}
+
+.cornelius-label, .cornelius-people {
+  border-bottom: 1px solid #E4E4E4;
+  border-right: 1px solid #E4E4E4;
+  font-weight: bold;
+  color: #3A3838
+}
+
+.cornelius-table tr:last-child td {
+  border-bottom: none;
+}
+
+.cornelius-empty {
+  background-color: #FFFFFF;
+  border: none;
+}
+
+.cornelius-low {
+  background-color: #F4F8FD;
+}
+
+.cornelius-medium-low {
+  background-color: #D8E6FF;
+}
+
+.cornelius-medium {
+  background-color: #A6CAFF;
+}
+
+.cornelius-medium-high {
+  background-color: #8FA4F8;
+}
+
+.cornelius-high {
+  background-color: #3963DD;
+}
+
+.cornelius-hot {
+  background-color: #163BA5;
+}
+
+.cornelius-extra-hot {
+  background-color: #041D66;
+}
+
+.cornelius-medium-high, .cornelius-high, .cornelius-hot, .cornelius-extra-hot {
+  color: #FFF;
+  -webkit-text-shadow: 1px 1px 1px black;
+  -moz-text-shadow: 1px 1px 1px black;
+  text-shadow: 1px 1px 1px black;
+}


### PR DESCRIPTION
This pull request introduces v0 of Retention. v0 includes
- Cohort Analysis: A cohort consists of a set of users who signed up in a given week and interacted with the bot in that week.
- The ability to select time ranges for which you want to look at retention numbers
- The ability to select granularity of retention numbers: (daily, weekly, monthly)

<img width="1200" alt="screen shot 2016-10-31 at 5 42 16 pm" src="https://cloud.githubusercontent.com/assets/1048/19876236/6b8a934e-9f91-11e6-85a9-677ee2565330.png">
