### PR TITLE
Add support for Facebook Referrals

### DIFF
--- a/app/assets/javascripts/pages/insights/filter.js.coffee
+++ b/app/assets/javascripts/pages/insights/filter.js.coffee
@@ -38,7 +38,7 @@ class App.Filter extends App.AppBase
         parent = $(@).closest('.query')
 
         switch
-          when $(@).val() in ['nickname', 'email', 'full_name', 'first_name', 'last_name', 'gender']
+          when $(@).val() in ['nickname', 'email', 'full_name', 'first_name', 'last_name', 'gender', 'ref']
             enable(parent, '.string-method')
 
             disable(parent, '.number-method')

--- a/app/lib/event_serializer/facebook.rb
+++ b/app/lib/event_serializer/facebook.rb
@@ -6,7 +6,8 @@ class EventSerializer::Facebook
                       optin: 'MessagingOptins',
                       account_linking: 'AccountLinking',
                       delivery: 'MessageDeliveries',
-                      read: 'MessageReads'
+                      read: 'MessageReads',
+                      referral: 'MessagingReferrals'
                     }
 
   def initialize(data, bi_uid)

--- a/app/lib/event_serializer/facebook/messaging_postbacks.rb
+++ b/app/lib/event_serializer/facebook/messaging_postbacks.rb
@@ -13,6 +13,9 @@ class EventSerializer::Facebook::MessagingPostbacks < EventSerializer::Facebook:
   end
 
   def event_attributes
-    { payload: @data.dig(:postback, :payload) }
+    {
+      payload: @data.dig(:postback, :payload),
+      referral: @data.dig(:postback, :referral)
+    }
   end
 end

--- a/app/lib/event_serializer/facebook/messaging_referrals.rb
+++ b/app/lib/event_serializer/facebook/messaging_referrals.rb
@@ -1,0 +1,20 @@
+class EventSerializer::Facebook::MessagingReferrals < EventSerializer::Facebook::Base
+  private
+  def data
+    {
+      event_type: 'messaging_referrals',
+      is_for_bot: false,
+      is_im: false,
+      is_from_bot: false,
+      provider: 'facebook',
+      created_at: timestamp,
+      event_attributes: event_attributes
+    }
+  end
+
+  def event_attributes
+    {
+      referral: @data.dig(:referral)
+    }
+  end
+end

--- a/app/models/bot_user.rb
+++ b/app/models/bot_user.rb
@@ -77,7 +77,7 @@ class BotUser < ActiveRecord::Base
     where(created_at: min..max)
   end
 
-  store_accessor :user_attributes, :nickname, :email, :full_name, :first_name, :last_name, :gender, :timezone
+  store_accessor :user_attributes, :nickname, :email, :full_name, :first_name, :last_name, :gender, :timezone, :ref
 
   def self.with_bot_instances(instances, bot, start_time, end_time)
     created_at = bot.provider == 'slack' ? "bot_instances.created_at" : "bot_users.created_at"

--- a/app/models/queries/facebook.rb
+++ b/app/models/queries/facebook.rb
@@ -4,13 +4,14 @@ module Queries
       'first_name'        => 'First Name',
       'last_name'         => 'Last Name',
       'gender'            => 'Gender',
+      'ref'               => 'Referrer',
       'interaction_count' => 'Number of Interactions with Bot',
       'interacted_at'     => 'Last Interacted With Bot',
-      'user_created_at'   => 'Signed Up',
+      'user_created_at'   => 'Signed Up'
     }
 
     def is_string_query?(field)
-      field.in?(['first_name', 'last_name', 'gender'])
+      field.in?(['first_name', 'last_name', 'gender', 'ref'])
     end
   end
 end

--- a/app/services/facebook_events_service.rb
+++ b/app/services/facebook_events_service.rb
@@ -26,7 +26,16 @@ class FacebookEventsService
         update_message_events!
       else
         @bot_user = bot_instance.users.find_by(uid: bot_user_uid) || BotUser.new(uid: bot_user_uid)
-        @bot_user.assign_attributes(bot_user_params) if @bot_user.new_record?
+        if @bot_user.new_record?
+          @bot_user.assign_attributes(bot_user_params)
+        else
+          ref = params.dig(:data, :event_attributes, :referral, :ref)
+          if ref.present?
+            @bot_user.user_attributes['ref'] = ref
+            @bot_user.save
+          end
+        end
+
         create_message_events!
       end
     end

--- a/app/services/facebook_events_service.rb
+++ b/app/services/facebook_events_service.rb
@@ -91,8 +91,12 @@ class FacebookEventsService
   end
 
   def bot_user_params
+    user_attributes = fetch_user.slice(*AVAILABLE_USER_FIELDS)
+    ref = params.dig(:data, :event_attributes, :referral, :ref)
+    user_attributes.merge!(ref: ref) if ref.present?
+
     {
-      user_attributes: fetch_user.slice(*AVAILABLE_USER_FIELDS),
+      user_attributes: user_attributes,
       bot_instance_id: bot_instance.id,
       provider: 'facebook',
       membership_type: 'user'

--- a/app/validators/event_type_validator.rb
+++ b/app/validators/event_type_validator.rb
@@ -1,6 +1,6 @@
 class EventTypeValidator < ActiveModel::Validator
   SLACK_EVENT_TYPES = %w(user_added bot_disabled added_to_channel message message_reaction)
-  FACEBOOK_EVENT_TYPES = %w(message messaging_optins messaging_postbacks account_linking)
+  FACEBOOK_EVENT_TYPES = %w(message messaging_optins messaging_postbacks account_linking messaging_referrals)
   KIK_EVENT_TYPES = %w(message)
 
   def validate(record)

--- a/app/views/dashboards/providers/_table_messages_to_from_bot_facebook.html.haml
+++ b/app/views/dashboards/providers/_table_messages_to_from_bot_facebook.html.haml
@@ -5,6 +5,7 @@
       %th Last Name
       %th Gender
       %th Timezone
+      %th Referrer
       %th Signed Up
       %th Bot Interactions
       %th Last Interacted with Bot
@@ -15,6 +16,7 @@
         %td= u.last_name
         %td= u.gender
         %td= ActiveSupport::TimeZone[u.timezone] if u.timezone.present?
+        %td= u.ref
         %td= "#{time_ago_in_words(u.created_at)} ago"
         %td= u.events_count
         %td= u.last_event_at.present? ? "#{time_ago_in_words(u.last_event_at)} ago" : 'no messages yet'

--- a/app/views/dashboards/providers/_table_new_users_facebook.html.haml
+++ b/app/views/dashboards/providers/_table_new_users_facebook.html.haml
@@ -5,6 +5,7 @@
       %th Last Name
       %th Gender
       %th Timezone
+      %th Referrer
       %th Signed Up
   %tbody
     - tableized.each do |u|
@@ -13,4 +14,5 @@
         %td= u.last_name
         %td= u.gender
         %td= ActiveSupport::TimeZone[u.timezone] if u.timezone.present?
+        %td= u.ref
         %td= "#{time_ago_in_words(u.created_at)} ago"

--- a/app/views/shared/filters/_tableized_facebook.html.haml
+++ b/app/views/shared/filters/_tableized_facebook.html.haml
@@ -7,6 +7,7 @@
           %th Last Name
           %th Gender
           %th Timezone
+          %th Referrer
           %th Signed Up
           %th Last Interacted With Bot
       %tbody
@@ -16,6 +17,7 @@
             %td= bot_user.last_name
             %td= bot_user.gender
             %td= ActiveSupport::TimeZone[bot_user.timezone]
+            %td= bot_user.ref
             %td= "#{time_ago_in_words(bot_user.created_at)} ago"
             %td= bot_user.last_interacted_with_bot_at.present? ? "#{time_ago_in_words(bot_user.last_interacted_with_bot_at)} ago" : '-'
     = will_paginate tableized, renderer: BootstrapPagination::Rails

--- a/db/migrate/20161108234028_add_messaging_referrals_to_event_type_constraint.rb
+++ b/db/migrate/20161108234028_add_messaging_referrals_to_event_type_constraint.rb
@@ -1,0 +1,41 @@
+class AddMessagingReferralsToEventTypeConstraint < ActiveRecord::Migration
+  def up
+    execute "ALTER TABLE events DROP CONSTRAINT IF EXISTS valid_event_type_on_events"
+    execute "ALTER TABLE events ADD CONSTRAINT valid_event_type_on_events
+                   CHECK (
+                          (
+                            event_type IN ('user_added', 'bot_disabled', 'added_to_channel', 'message', 'message_reaction')
+                          ) AND provider = 'slack'
+                          OR (
+                            (
+                              event_type IN ('message', 'messaging_postbacks', 'messaging_optins', 'account_linking', 'messaging_referrals')
+                            ) AND provider = 'facebook'
+                          ) AND bot_user_id IS NOT NULL
+                          OR (
+                            (
+                              event_type = 'message'
+                            ) AND provider = 'kik'
+                          ) AND bot_user_id IS NOT NULL
+                        )"
+  end
+
+  def down
+    execute "ALTER TABLE events DROP CONSTRAINT valid_event_type_on_events"
+    execute "ALTER TABLE events ADD CONSTRAINT valid_event_type_on_events
+                   CHECK (
+                          (
+                            event_type IN ('user_added', 'bot_disabled', 'added_to_channel', 'message', 'message_reaction')
+                          ) AND provider = 'slack'
+                          OR (
+                            (
+                              event_type IN ('message', 'messaging_postbacks', 'messaging_optins', 'account_linking')
+                            ) AND provider = 'facebook'
+                          ) AND bot_user_id IS NOT NULL
+                          OR (
+                            (
+                              event_type = 'message'
+                            ) AND provider = 'kik'
+                          ) AND bot_user_id IS NOT NULL
+                        )"
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -284,7 +284,7 @@ CREATE TABLE events (
     text text,
     has_been_delivered boolean DEFAULT false,
     has_been_read boolean DEFAULT false,
-    CONSTRAINT valid_event_type_on_events CHECK ((((((event_type)::text = ANY (ARRAY[('user_added'::character varying)::text, ('bot_disabled'::character varying)::text, ('added_to_channel'::character varying)::text, ('message'::character varying)::text, ('message_reaction'::character varying)::text])) AND ((provider)::text = 'slack'::text)) OR ((((event_type)::text = ANY (ARRAY[('message'::character varying)::text, ('messaging_postbacks'::character varying)::text, ('messaging_optins'::character varying)::text, ('account_linking'::character varying)::text])) AND ((provider)::text = 'facebook'::text)) AND (bot_user_id IS NOT NULL))) OR ((((event_type)::text = 'message'::text) AND ((provider)::text = 'kik'::text)) AND (bot_user_id IS NOT NULL)))),
+    CONSTRAINT valid_event_type_on_events CHECK ((((((event_type)::text = ANY ((ARRAY['user_added'::character varying, 'bot_disabled'::character varying, 'added_to_channel'::character varying, 'message'::character varying, 'message_reaction'::character varying])::text[])) AND ((provider)::text = 'slack'::text)) OR ((((event_type)::text = ANY ((ARRAY['message'::character varying, 'messaging_postbacks'::character varying, 'messaging_optins'::character varying, 'account_linking'::character varying, 'messaging_referrals'::character varying])::text[])) AND ((provider)::text = 'facebook'::text)) AND (bot_user_id IS NOT NULL))) OR ((((event_type)::text = 'message'::text) AND ((provider)::text = 'kik'::text)) AND (bot_user_id IS NOT NULL)))),
     CONSTRAINT valid_provider_on_events CHECK ((((((provider)::text = 'slack'::text) OR ((provider)::text = 'kik'::text)) OR ((provider)::text = 'facebook'::text)) OR ((provider)::text = 'telegram'::text))),
     CONSTRAINT validate_attributes_channel CHECK ((((((((event_attributes ->> 'channel'::text) IS NOT NULL) AND (length((event_attributes ->> 'channel'::text)) > 0)) AND ((provider)::text = 'slack'::text)) AND (((event_type)::text = 'message'::text) OR ((event_type)::text = 'message_reaction'::text))) OR ((((provider)::text = 'slack'::text) AND (((event_type)::text <> 'message'::text) AND ((event_type)::text <> 'message_reaction'::text))) AND (event_attributes IS NOT NULL))) OR ((provider)::text = ANY (ARRAY[('facebook'::character varying)::text, ('kik'::character varying)::text])))),
     CONSTRAINT validate_attributes_chat_id CHECK (((((((event_attributes ->> 'chat_id'::text) IS NOT NULL) AND (length((event_attributes ->> 'chat_id'::text)) > 0)) AND ((provider)::text = 'kik'::text)) AND ((event_type)::text = 'message'::text)) OR ((provider)::text = ANY (ARRAY[('facebook'::character varying)::text, ('slack'::character varying)::text])))),
@@ -1372,4 +1372,6 @@ INSERT INTO schema_migrations (version) VALUES ('20161012225313');
 INSERT INTO schema_migrations (version) VALUES ('20161031165417');
 
 INSERT INTO schema_migrations (version) VALUES ('20161107211020');
+
+INSERT INTO schema_migrations (version) VALUES ('20161108234028');
 

--- a/spec/lib/event_serializer/facebook/messaging_postbacks_spec.rb
+++ b/spec/lib/event_serializer/facebook/messaging_postbacks_spec.rb
@@ -34,7 +34,8 @@ RSpec.describe EventSerializer::Facebook::MessagingPostbacks do
           provider: "facebook",
           created_at: Time.at(timestamp.to_f / 1000),
           event_attributes: {
-            payload: "USER_DEFINED_PAYLOAD"
+            payload: "USER_DEFINED_PAYLOAD",
+            referral: nil
           }},
         recip_info: {
           sender_id: "USER_ID", recipient_id: "PAGE_ID"

--- a/spec/lib/event_serializer/facebook/messaging_referrals_spec.rb
+++ b/spec/lib/event_serializer/facebook/messaging_referrals_spec.rb
@@ -1,0 +1,55 @@
+RSpec.describe EventSerializer::Facebook::MessagingReferrals do
+  let!(:timestamp)    { Time.now.to_i * 1000 }
+
+  describe '.new' do
+    context 'invalid params' do
+      it { expect { EventSerializer::Facebook.new(nil, 'bi_uid') }.to raise_error('Supplied Option Is Nil') }
+    end
+  end
+
+  describe '#serialize' do
+    subject { EventSerializer::Facebook::MessagingReferrals.new(data).serialize }
+
+    let(:data) {
+      {
+        "sender":{
+          "id":"USER_ID"
+        },
+        "recipient":{
+          "id":"PAGE_ID"
+        },
+        "timestamp":timestamp,
+        "referral":{
+          "ref":"producthunt",
+          "source": "SHORTLINK",
+          "type": "OPEN_THREAD"
+        }
+      }
+    }
+    let(:serialized) {
+      {
+        data:  {
+          event_type: "messaging_referrals",
+          is_for_bot: false,
+          is_im: false,
+          is_from_bot: false,
+          provider: "facebook",
+          created_at: Time.at(timestamp.to_f / 1000),
+          event_attributes: {
+            referral: {
+              ref: "producthunt",
+              source: "SHORTLINK",
+              type: "OPEN_THREAD"
+            }
+          }
+        },
+        recip_info: {
+          sender_id: "USER_ID", recipient_id: "PAGE_ID"
+        }
+      }
+    }
+
+    it { expect(subject).to eql serialized }
+  end
+end
+

--- a/spec/models/queries/facebook_spec.rb
+++ b/spec/models/queries/facebook_spec.rb
@@ -22,6 +22,7 @@ RSpec.describe Queries::Facebook do
                      'first_name', 'First Name',
                      'last_name', 'Last Name',
                      'gender', 'Gender',
+                     'ref', 'Referrer',
                      'interaction_count', 'Number of Interactions with Bot',
                      'interacted_at', 'Last Interacted With Bot',
                      'user_created_at', 'Signed Up'

--- a/spec/services/facebook_events_service_spec.rb
+++ b/spec/services/facebook_events_service_spec.rb
@@ -501,6 +501,61 @@ RSpec.describe FacebookEventsService do
     context "bot user does not exist" do
       it_behaves_like "should create an event but not create any bot users"
     end
+
+    context "with referral in the message payload" do
+      let(:events) do
+        {
+          "entry": [{
+            "id": "268855423495782",
+            "time": 1470403317713,
+            "messaging": [{
+              "sender":{
+                "id": fb_user_id
+              },
+              "recipient":{
+                "id": bot_user_id
+              },
+              "timestamp": timestamp,
+              "postback":{
+                "payload": "USER_DEFINED_PAYLOAD",
+                "referral": {
+                  "ref": "producthunt",
+                  "source": "SHORT_LINK",
+                  "type": "OPEN_THREAD"
+                }
+              }
+            }]
+          }]
+        }
+      end
+
+      context "bot user exists" do
+        it_behaves_like "should create an event as well as create the bot users"
+      end
+
+      context "bot user does not exist" do
+        it_behaves_like "should create an event but not create any bot users"
+      end
+
+      it "should create a new BotUser with the 'ref' set to 'producthunt' in user_attributes" do
+        expect {
+          do_request
+          bot_instance.reload
+        }.to change(bot_instance.users, :count).by(1)
+
+        user = bot_instance.users.last
+        expect(user.user_attributes['first_name']).to eql first_name
+        expect(user.user_attributes['last_name']).to eql last_name
+        expect(user.user_attributes['profile_pic']).to eql profile_pic
+        expect(user.user_attributes['locale']).to eql locale
+        expect(user.user_attributes['timezone']).to eql timezone
+        expect(user.user_attributes['gender']).to eql gender
+        expect(user.user_attributes['ref']).to eql 'producthunt'
+        expect(user.uid).to eql fb_user_id
+        expect(user.provider).to eql 'facebook'
+        expect(user.membership_type).to eql 'user'
+      end
+    end
   end
 
   describe '"account_linking" event' do


### PR DESCRIPTION
* Add support for new `messaging_referrals` webhook
* Add support for new adding `ref` attribute to users when `https://m.me/<bot>` is called with a `ref` parameter
* Insights and notifications now let you segment users based on referrer