### PR TITLE
Add support for user enrichment API

### DIFF
--- a/app/controllers/bot_users_controller.rb
+++ b/app/controllers/bot_users_controller.rb
@@ -1,0 +1,20 @@
+class BotUsersController < ApplicationController
+  before_action :authenticate_user!
+  before_action :find_bot
+
+  def update
+    @bot_user = BotUser.where(uid: params[:id], bot_instance_id: @bot.instances.select(:id)).first
+    raise ActiveRecord::RecordNotFound if @bot_user.blank?
+
+    if (tz = params[:user][:timezone]).present? && ActiveSupport::TimeZone[tz].present?
+      @bot_user.user_attributes[:timezone] = tz
+      @bot_user.save
+
+      head :accepted
+    else
+      respond_to do |format|
+        format.json { render json: { error: "no valid timezone provided" }, status: :bad_request }
+      end
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,6 +18,8 @@ Rails.application.routes.draw do
       end
     end
 
+    resources :users, controller: "bot_users", only: [:update], as: :users
+
     resources :retention, only: [:index]
 
     resources :notifications, except: [:new, :create, :edit, :update]

--- a/spec/controllers/bot_users_controller_spec.rb
+++ b/spec/controllers/bot_users_controller_spec.rb
@@ -1,0 +1,75 @@
+require 'rails_helper'
+
+RSpec.describe BotUsersController, type: :controller do
+  describe 'PATCH update' do
+    let!(:user) { create :user }
+    let!(:bot)  { create :bot }
+
+    let!(:bc1)  { create :bot_collaborator, bot: bot, user: user }
+
+    let!(:bi1) { create :bot_instance, bot: bot }
+    let!(:bi2) { create :bot_instance, bot: bot }
+    let!(:bu1) { create :bot_user, bot_instance: bi1 }
+    let!(:bu2) { create :bot_user, bot_instance: bi2 }
+    let!(:bu3) { create :bot_user, bot_instance: bi2 }
+    let!(:bu4) { create :bot_user }
+
+    before { sign_in user }
+
+    def do_request(user, timezone)
+      patch :update, bot_id: bot.uid, id: user.uid, format: :json, user: { timezone: timezone }
+    end
+
+    context 'missing bot user' do
+      it "should NOT update the user's timezone" do
+        expect {
+          do_request(bu4, 'GMT1')
+          bu4.reload
+        }.to_not change(bu4, :timezone)
+      end
+
+      it "should respond with :accepted" do
+        do_request(bu4, 'GMT1')
+        expect(response).to have_http_status :missing
+      end
+    end
+
+    context 'valid timezone' do
+      it "should update the user's timezone" do
+        expect {
+          do_request(bu1, 'GMT')
+          bu1.reload
+        }.to change(bu1, :timezone).to 'GMT'
+
+        expect {
+          do_request(bu2, 'GMT')
+          bu2.reload
+        }.to change(bu2, :timezone).to 'GMT'
+
+        expect {
+          do_request(bu3, 'GMT')
+          bu3.reload
+        }.to change(bu3, :timezone).to 'GMT'
+      end
+
+      it 'should respond with :accepted' do
+        do_request(bu1, 'GMT')
+        expect(response).to have_http_status :accepted
+      end
+    end
+
+    context 'invalid timezone' do
+      it "should NOT update the user's timezone" do
+        expect {
+          do_request(bu1, 'GMT1')
+          bu1.reload
+        }.to_not change(bu1, :timezone)
+      end
+
+      it "should respond with :accepted" do
+        do_request(bu1, 'GMT1')
+        expect(response).to have_http_status :bad_request
+      end
+    end
+  end
+end


### PR DESCRIPTION
With the User Enrichment API, you can add attributes to the user (for e.g. adding timezones for Kik users, since Kik doesn't give you timezone information)

To use the enrichment API and to update a user with the "GMT" timezone, make an HTTP request like so (**with your API Key in the Authorization Header**):

`curl -X PATCH https://www.getbotmetrics.com/bots/<your-bot-id>/users/<unique-id-of-user>?user[timezone]=GMT&format=json`

If you are running your own private install of Botmetrics, replace `www.getbotmetrics.com` with the hostname of your private install.