### PR TITLE
Simplified Facebook Event Types

### DIFF
--- a/app/lib/event_serializer/facebook/message.rb
+++ b/app/lib/event_serializer/facebook/message.rb
@@ -2,7 +2,7 @@ class EventSerializer::Facebook::Message < EventSerializer::Facebook::Base
   private
   def data
     {
-      event_type: 'message',
+      event_type: event_type,
       is_for_bot: true,
       is_im: true,
       is_from_bot: false,
@@ -34,6 +34,24 @@ class EventSerializer::Facebook::Message < EventSerializer::Facebook::Base
 
   def attachments
     @data.dig(:message, :attachments)
+  end
+
+  def event_type
+    _attachments = attachments
+    event_type = 'message'
+
+    if _attachments&.any?
+      event_type = case attachments[0][:type]
+                     when 'image'    then 'message:image-uploaded'
+                     when 'video'    then 'message:video-uploaded'
+                     when 'audio'    then 'message:audio-uploaded'
+                     when 'file'     then 'message:file-uploaded'
+                     when 'location' then 'message:location-sent'
+                     else 'message'
+                   end
+    end
+
+    event_type
   end
 
   def quick_reply

--- a/app/validators/event_type_validator.rb
+++ b/app/validators/event_type_validator.rb
@@ -1,6 +1,6 @@
 class EventTypeValidator < ActiveModel::Validator
   SLACK_EVENT_TYPES = %w(user_added bot_disabled added_to_channel message message_reaction)
-  FACEBOOK_EVENT_TYPES = %w(message messaging_optins messaging_postbacks account_linking messaging_referrals)
+  FACEBOOK_EVENT_TYPES = %w(message message:image-uploaded message:video-uploaded message:audio-uploaded message:file-uploaded message:location-sent messaging_optins messaging_postbacks account_linking messaging_referrals)
   KIK_EVENT_TYPES = %w(message)
 
   def validate(record)

--- a/db/migrate/20161128001426_add_event_subtypes_to_facebook_event_constraints.rb
+++ b/db/migrate/20161128001426_add_event_subtypes_to_facebook_event_constraints.rb
@@ -1,0 +1,41 @@
+class AddEventSubtypesToFacebookEventConstraints < ActiveRecord::Migration
+  def up
+    execute "ALTER TABLE events DROP CONSTRAINT IF EXISTS valid_event_type_on_events"
+    execute "ALTER TABLE events ADD CONSTRAINT valid_event_type_on_events
+                   CHECK (
+                          (
+                            event_type IN ('user_added', 'bot_disabled', 'added_to_channel', 'message', 'message_reaction')
+                          ) AND provider = 'slack'
+                          OR (
+                            (
+                              event_type IN ('message', 'messaging_postbacks', 'messaging_optins', 'account_linking', 'messaging_referrals', 'message:image-uploaded', 'message:audio-uploaded', 'message:video-uploaded', 'message:file-uploaded', 'message:location-sent')
+                            ) AND provider = 'facebook'
+                          ) AND bot_user_id IS NOT NULL
+                          OR (
+                            (
+                              event_type = 'message'
+                            ) AND provider = 'kik'
+                          ) AND bot_user_id IS NOT NULL
+                        )"
+  end
+
+  def down
+    execute "ALTER TABLE events DROP CONSTRAINT IF EXISTS valid_event_type_on_events"
+    execute "ALTER TABLE events ADD CONSTRAINT valid_event_type_on_events
+                   CHECK (
+                          (
+                            event_type IN ('user_added', 'bot_disabled', 'added_to_channel', 'message', 'message_reaction')
+                          ) AND provider = 'slack'
+                          OR (
+                            (
+                              event_type IN ('message', 'messaging_postbacks', 'messaging_optins', 'account_linking', 'messaging_referrals')
+                            ) AND provider = 'facebook'
+                          ) AND bot_user_id IS NOT NULL
+                          OR (
+                            (
+                              event_type = 'message'
+                            ) AND provider = 'kik'
+                          ) AND bot_user_id IS NOT NULL
+                        )"
+  end
+end

--- a/db/migrate/20161128001912_update_facebook_event_type.rb
+++ b/db/migrate/20161128001912_update_facebook_event_type.rb
@@ -1,0 +1,24 @@
+class UpdateFacebookEventType < ActiveRecord::Migration
+  def up
+    execute <<-SQL
+  UPDATE events
+  SET event_type = CASE (event_attributes->'attachments'->0->>'type')::text
+                     WHEN 'image'    THEN 'message:image-uploaded'
+                     WHEN 'video'    THEN 'message:video-uploaded'
+                     WHEN 'audio'    THEN 'message:audio-uploaded'
+                     WHEN 'file'     THEN 'message:file-uploaded'
+                     WHEN 'location' THEN 'message:location-sent'
+                     ELSE                 'message'
+                   END
+  WHERE events.provider = 'facebook' AND (event_attributes->'attachments')::text IS NOT NULL;
+SQL
+  end
+
+  def down
+    execute <<-SQL
+  UPDATE events
+  SET event_type = 'message'
+  WHERE events.provider = 'facebook' AND (event_attributes->'attachments')::text IS NOT NULL;
+SQL
+  end
+end

--- a/db/migrate/20161128033354_modify_uniqueness_index_for_facebook_events.rb
+++ b/db/migrate/20161128033354_modify_uniqueness_index_for_facebook_events.rb
@@ -1,0 +1,22 @@
+class ModifyUniquenessIndexForFacebookEvents < ActiveRecord::Migration
+  def up
+    execute "DROP INDEX events_mid_seq_facebook"
+    execute <<-SQL
+      CREATE UNIQUE INDEX events_mid_seq_facebook ON events((event_attributes->'mid'), (event_attributes->'seq'))
+      WHERE events.provider = 'facebook' AND
+      (
+        events.event_type = 'message' OR
+        events.event_type = 'message:image-uploaded' OR
+        events.event_type = 'message:video-uploaded' OR
+        events.event_type = 'message:file-uploaded' OR
+        events.event_type = 'message:location-sent' OR
+        events.event_type = 'message:audio-uploaded'
+      )
+SQL
+  end
+
+  def down
+    execute "DROP INDEX events_mid_seq_facebook"
+    execute "CREATE UNIQUE INDEX events_mid_seq_facebook ON events((event_attributes->'mid'), (event_attributes->'seq')) WHERE events.provider = 'facebook' AND events.event_type = 'message'"
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -836,7 +836,7 @@ CREATE UNIQUE INDEX events_id_kik ON events USING btree (((event_attributes -> '
 -- Name: events_mid_seq_facebook; Type: INDEX; Schema: public; Owner: -; Tablespace:
 --
 
-CREATE UNIQUE INDEX events_mid_seq_facebook ON events USING btree (((event_attributes -> 'mid'::text)), ((event_attributes -> 'seq'::text))) WHERE (((provider)::text = 'facebook'::text) AND ((event_type)::text = 'message'::text));
+CREATE UNIQUE INDEX events_mid_seq_facebook ON events USING btree (((event_attributes -> 'mid'::text)), ((event_attributes -> 'seq'::text))) WHERE (((provider)::text = 'facebook'::text) AND (((((((event_type)::text = 'message'::text) OR ((event_type)::text = 'message:image-uploaded'::text)) OR ((event_type)::text = 'message:video-uploaded'::text)) OR ((event_type)::text = 'message:file-uploaded'::text)) OR ((event_type)::text = 'message:location-sent'::text)) OR ((event_type)::text = 'message:audio-uploaded'::text)));
 
 
 --
@@ -1382,4 +1382,6 @@ INSERT INTO schema_migrations (version) VALUES ('20161127201529');
 INSERT INTO schema_migrations (version) VALUES ('20161128001426');
 
 INSERT INTO schema_migrations (version) VALUES ('20161128001912');
+
+INSERT INTO schema_migrations (version) VALUES ('20161128033354');
 

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -285,7 +285,7 @@ CREATE TABLE events (
     text text,
     has_been_delivered boolean DEFAULT false,
     has_been_read boolean DEFAULT false,
-    CONSTRAINT valid_event_type_on_events CHECK ((((((event_type)::text = ANY (ARRAY[('user_added'::character varying)::text, ('bot_disabled'::character varying)::text, ('added_to_channel'::character varying)::text, ('message'::character varying)::text, ('message_reaction'::character varying)::text])) AND ((provider)::text = 'slack'::text)) OR ((((event_type)::text = ANY (ARRAY[('message'::character varying)::text, ('messaging_postbacks'::character varying)::text, ('messaging_optins'::character varying)::text, ('account_linking'::character varying)::text, ('messaging_referrals'::character varying)::text])) AND ((provider)::text = 'facebook'::text)) AND (bot_user_id IS NOT NULL))) OR ((((event_type)::text = 'message'::text) AND ((provider)::text = 'kik'::text)) AND (bot_user_id IS NOT NULL)))),
+    CONSTRAINT valid_event_type_on_events CHECK ((((((event_type)::text = ANY ((ARRAY['user_added'::character varying, 'bot_disabled'::character varying, 'added_to_channel'::character varying, 'message'::character varying, 'message_reaction'::character varying])::text[])) AND ((provider)::text = 'slack'::text)) OR ((((event_type)::text = ANY ((ARRAY['message'::character varying, 'messaging_postbacks'::character varying, 'messaging_optins'::character varying, 'account_linking'::character varying, 'messaging_referrals'::character varying, 'message:image-uploaded'::character varying, 'message:audio-uploaded'::character varying, 'message:video-uploaded'::character varying, 'message:file-uploaded'::character varying, 'message:location-sent'::character varying])::text[])) AND ((provider)::text = 'facebook'::text)) AND (bot_user_id IS NOT NULL))) OR ((((event_type)::text = 'message'::text) AND ((provider)::text = 'kik'::text)) AND (bot_user_id IS NOT NULL)))),
     CONSTRAINT valid_provider_on_events CHECK ((((((provider)::text = 'slack'::text) OR ((provider)::text = 'kik'::text)) OR ((provider)::text = 'facebook'::text)) OR ((provider)::text = 'telegram'::text))),
     CONSTRAINT validate_attributes_channel CHECK ((((((((event_attributes ->> 'channel'::text) IS NOT NULL) AND (length((event_attributes ->> 'channel'::text)) > 0)) AND ((provider)::text = 'slack'::text)) AND (((event_type)::text = 'message'::text) OR ((event_type)::text = 'message_reaction'::text))) OR ((((provider)::text = 'slack'::text) AND (((event_type)::text <> 'message'::text) AND ((event_type)::text <> 'message_reaction'::text))) AND (event_attributes IS NOT NULL))) OR ((provider)::text = ANY (ARRAY[('facebook'::character varying)::text, ('kik'::character varying)::text])))),
     CONSTRAINT validate_attributes_id CHECK (((((((event_attributes ->> 'id'::text) IS NOT NULL) AND (length((event_attributes ->> 'id'::text)) > 0)) AND ((provider)::text = 'kik'::text)) AND ((event_type)::text = 'message'::text)) OR ((provider)::text = ANY (ARRAY[('facebook'::character varying)::text, ('slack'::character varying)::text])))),
@@ -1378,4 +1378,8 @@ INSERT INTO schema_migrations (version) VALUES ('20161108234028');
 INSERT INTO schema_migrations (version) VALUES ('20161110174157');
 
 INSERT INTO schema_migrations (version) VALUES ('20161127201529');
+
+INSERT INTO schema_migrations (version) VALUES ('20161128001426');
+
+INSERT INTO schema_migrations (version) VALUES ('20161128001912');
 

--- a/spec/services/facebook_events_service_spec.rb
+++ b/spec/services/facebook_events_service_spec.rb
@@ -59,7 +59,9 @@ RSpec.describe FacebookEventsService do
       expect(event.provider).to eql 'facebook'
       expect(event.user).to eql BotUser.find_by(uid: fb_user_id)
       expect(event.event_attributes.slice(*required_event_attributes.keys)).to eql required_event_attributes
-      expect(event.text).to eql text
+      if text.present?
+        expect(event.text).to eql text
+      end
       expect(event.created_at.to_i).to eql timestamp / 1000
       expect(event.is_from_bot).to be is_from_bot
       expect(event.is_im).to be is_im
@@ -124,7 +126,9 @@ RSpec.describe FacebookEventsService do
       expect(event.provider).to eql 'facebook'
       expect(event.user).to eql user
       expect(event.event_attributes.slice(*required_event_attributes.keys)).to eql required_event_attributes
-      expect(event.text).to eql text
+      if text.present?
+        expect(event.text).to eql text
+      end
       expect(event.created_at.to_i).to eql timestamp / 1000
       expect(event.is_from_bot).to be is_from_bot
       expect(event.is_im).to be is_im
@@ -227,6 +231,344 @@ RSpec.describe FacebookEventsService do
     context "bot user does not exist" do
       it_behaves_like "should create an event but not create any bot users"
       it_behaves_like "associates event with custom dashboard if custom dashboards exist"
+
+      it "should succeed if the same call is called more than once" do
+        expect {
+          do_request
+          do_request
+          bot_instance.reload
+        }.to change(bot_instance.events, :count).by(1)
+      end
+    end
+  end
+
+  describe '"messages" event with "image" attachment' do
+    let(:fb_user_id)    { "fb-user-id"                 }
+    let(:bot_user_id)   { bot.uid                      }
+    let(:mid)           { "mid-1"                      }
+    let(:seq)           { 8888                         }
+    let(:text)          { nil                          }
+    let(:event_type)    { 'message:image-uploaded'     }
+    let(:is_from_bot)   { false                        }
+    let(:is_for_bot)    { true                         }
+    let(:is_im)         { true                         }
+    let(:required_event_attributes) {
+      Hash["mid", "mid-1", "seq", 8888]
+    }
+
+    let(:events) do
+      {
+        "entry": [{
+          "id": "268855423495782",
+          "time": 1470403317713,
+          "messaging": [{
+            "sender":{
+              "id": fb_user_id
+            },
+            "recipient":{
+              "id": bot_user_id
+            },
+            "timestamp": timestamp,
+            "message":{
+              "mid": required_event_attributes['mid'],
+              "seq": required_event_attributes['seq'],
+              "attachments": [
+                {
+                  "type": "image",
+                  "payload": "IMAGE_URL"
+                }
+              ]
+            }
+          }]
+        }]
+      }
+    end
+
+    context "bot user exists" do
+      it_behaves_like "should create an event as well as create the bot users"
+
+      it "should succeed if the same call is called more than once" do
+        expect {
+          do_request
+          do_request
+          bot_instance.reload
+        }.to change(bot_instance.events, :count).by(1)
+      end
+    end
+
+    context "bot user does not exist" do
+      it_behaves_like "should create an event but not create any bot users"
+
+      it "should succeed if the same call is called more than once" do
+        expect {
+          do_request
+          do_request
+          bot_instance.reload
+        }.to change(bot_instance.events, :count).by(1)
+      end
+    end
+  end
+
+  describe '"messages" event with "video" attachment' do
+    let(:fb_user_id)    { "fb-user-id"                 }
+    let(:bot_user_id)   { bot.uid                      }
+    let(:mid)           { "mid-1"                      }
+    let(:seq)           { 8888                         }
+    let(:text)          { nil                          }
+    let(:event_type)    { 'message:video-uploaded'     }
+    let(:is_from_bot)   { false                        }
+    let(:is_for_bot)    { true                         }
+    let(:is_im)         { true                         }
+    let(:required_event_attributes) {
+      Hash["mid", "mid-1", "seq", 8888]
+    }
+
+    let(:events) do
+      {
+        "entry": [{
+          "id": "268855423495782",
+          "time": 1470403317713,
+          "messaging": [{
+            "sender":{
+              "id": fb_user_id
+            },
+            "recipient":{
+              "id": bot_user_id
+            },
+            "timestamp": timestamp,
+            "message":{
+              "mid": required_event_attributes['mid'],
+              "seq": required_event_attributes['seq'],
+              "attachments": [
+                {
+                  "type": "video",
+                  "payload": "VIDEO_URL"
+                }
+              ]
+            }
+          }]
+        }]
+      }
+    end
+
+    context "bot user exists" do
+      it_behaves_like "should create an event as well as create the bot users"
+
+      it "should succeed if the same call is called more than once" do
+        expect {
+          do_request
+          do_request
+          bot_instance.reload
+        }.to change(bot_instance.events, :count).by(1)
+      end
+    end
+
+    context "bot user does not exist" do
+      it_behaves_like "should create an event but not create any bot users"
+
+      it "should succeed if the same call is called more than once" do
+        expect {
+          do_request
+          do_request
+          bot_instance.reload
+        }.to change(bot_instance.events, :count).by(1)
+      end
+    end
+  end
+
+  describe '"messages" event with "audio" attachment' do
+    let(:fb_user_id)    { "fb-user-id"                 }
+    let(:bot_user_id)   { bot.uid                      }
+    let(:mid)           { "mid-1"                      }
+    let(:seq)           { 8888                         }
+    let(:text)          { nil                          }
+    let(:event_type)    { 'message:audio-uploaded'     }
+    let(:is_from_bot)   { false                        }
+    let(:is_for_bot)    { true                         }
+    let(:is_im)         { true                         }
+    let(:required_event_attributes) {
+      Hash["mid", "mid-1", "seq", 8888]
+    }
+
+    let(:events) do
+      {
+        "entry": [{
+          "id": "268855423495782",
+          "time": 1470403317713,
+          "messaging": [{
+            "sender":{
+              "id": fb_user_id
+            },
+            "recipient":{
+              "id": bot_user_id
+            },
+            "timestamp": timestamp,
+            "message":{
+              "mid": required_event_attributes['mid'],
+              "seq": required_event_attributes['seq'],
+              "attachments": [
+                {
+                  "type": "audio",
+                  "payload": "AUDIO_URL"
+                }
+              ]
+            }
+          }]
+        }]
+      }
+    end
+
+    context "bot user exists" do
+      it_behaves_like "should create an event as well as create the bot users"
+
+      it "should succeed if the same call is called more than once" do
+        expect {
+          do_request
+          do_request
+          bot_instance.reload
+        }.to change(bot_instance.events, :count).by(1)
+      end
+    end
+
+    context "bot user does not exist" do
+      it_behaves_like "should create an event but not create any bot users"
+
+      it "should succeed if the same call is called more than once" do
+        expect {
+          do_request
+          do_request
+          bot_instance.reload
+        }.to change(bot_instance.events, :count).by(1)
+      end
+    end
+  end
+
+  describe '"messages" event with "file" attachment' do
+    let(:fb_user_id)    { "fb-user-id"                 }
+    let(:bot_user_id)   { bot.uid                      }
+    let(:mid)           { "mid-1"                      }
+    let(:seq)           { 8888                         }
+    let(:text)          { nil                          }
+    let(:event_type)    { 'message:file-uploaded'      }
+    let(:is_from_bot)   { false                        }
+    let(:is_for_bot)    { true                         }
+    let(:is_im)         { true                         }
+    let(:required_event_attributes) {
+      Hash["mid", "mid-1", "seq", 8888]
+    }
+
+    let(:events) do
+      {
+        "entry": [{
+          "id": "268855423495782",
+          "time": 1470403317713,
+          "messaging": [{
+            "sender":{
+              "id": fb_user_id
+            },
+            "recipient":{
+              "id": bot_user_id
+            },
+            "timestamp": timestamp,
+            "message":{
+              "mid": required_event_attributes['mid'],
+              "seq": required_event_attributes['seq'],
+              "attachments": [
+                {
+                  "type": "file",
+                  "payload": "FILE_URL"
+                }
+              ]
+            }
+          }]
+        }]
+      }
+    end
+
+    context "bot user exists" do
+      it_behaves_like "should create an event as well as create the bot users"
+
+      it "should succeed if the same call is called more than once" do
+        expect {
+          do_request
+          do_request
+          bot_instance.reload
+        }.to change(bot_instance.events, :count).by(1)
+      end
+    end
+
+    context "bot user does not exist" do
+      it_behaves_like "should create an event but not create any bot users"
+
+      it "should succeed if the same call is called more than once" do
+        expect {
+          do_request
+          do_request
+          bot_instance.reload
+        }.to change(bot_instance.events, :count).by(1)
+      end
+    end
+  end
+
+  describe '"messages" event with "location" attachment' do
+    let(:fb_user_id)    { "fb-user-id"                 }
+    let(:bot_user_id)   { bot.uid                      }
+    let(:mid)           { "mid-1"                      }
+    let(:seq)           { 8888                         }
+    let(:text)          { nil                          }
+    let(:event_type)    { 'message:location-sent'      }
+    let(:is_from_bot)   { false                        }
+    let(:is_for_bot)    { true                         }
+    let(:is_im)         { true                         }
+    let(:required_event_attributes) {
+      Hash["mid", "mid-1", "seq", 8888]
+    }
+
+    let(:events) do
+      {
+        "entry": [{
+          "id": "268855423495782",
+          "time": 1470403317713,
+          "messaging": [{
+            "sender":{
+              "id": fb_user_id
+            },
+            "recipient":{
+              "id": bot_user_id
+            },
+            "timestamp": timestamp,
+            "message":{
+              "mid": required_event_attributes['mid'],
+              "seq": required_event_attributes['seq'],
+              "attachments": [
+                {
+                  "type": "location",
+                  "payload": {
+                    "coordinates.lat": "LAT",
+                    "coordinates.lng": "LNG"
+                  }
+                }
+              ]
+            }
+          }]
+        }]
+      }
+    end
+
+    context "bot user exists" do
+      it_behaves_like "should create an event as well as create the bot users"
+
+      it "should succeed if the same call is called more than once" do
+        expect {
+          do_request
+          do_request
+          bot_instance.reload
+        }.to change(bot_instance.events, :count).by(1)
+      end
+    end
+
+    context "bot user does not exist" do
+      it_behaves_like "should create an event but not create any bot users"
 
       it "should succeed if the same call is called more than once" do
         expect {


### PR DESCRIPTION
This change will allow us to query for events such as Image Uploads, Video Uploads with `event_type` as opposed to querying for the `event_attributes` JSON blob