### PR TITLE
Convert nil param to string to raise correct error

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -22,7 +22,7 @@ class EventsController < ApplicationController
   protected
   def validate_event!
     begin
-      event = JSON.parse(params[:event])
+      event = JSON.parse(params[:event].to_s)
     rescue JSON::ParserError
       @error = "Event parameter is not valid JSON"
       raise BadEventError


### PR DESCRIPTION
while parsing events

Signed-off-by: arunthampi <arun.thampi@gmail.com>